### PR TITLE
Improve typing of `Workforce.map` and `ultimap`

### DIFF
--- a/ultima/_mapping.py
+++ b/ultima/_mapping.py
@@ -2,8 +2,8 @@ from math import ceil
 from functools import partial
 from collections.abc import Sized
 from concurrent.futures import BrokenExecutor
-from typing import Optional, Callable, Iterable, List, Collection, \
-    Union, Tuple, Any, Generic, TypeVar, TYPE_CHECKING, get_args
+from typing import Optional, Callable, Iterable, Iterator, List, \
+    Collection, Generic, TypeVar, TYPE_CHECKING, get_args
 
 from .bfr import BufferedFutureResolver, KeyedFuture
 from .args import Args
@@ -65,8 +65,8 @@ class Mapping(Generic[T]):
     """
     logger = class_logger()
 
-    def __init__(self, workforce: "Workforce", func: Callable[..., T], inputs: Iterable, ordered: bool = False,
-                 buffering: Optional[int] = None, batch_size: int = 1, errors: Error = 'raise',
+    def __init__(self, workforce: "Workforce", func: Callable, inputs: Iterable,
+                 ordered: bool = False, buffering: Optional[int] = None, batch_size: int = 1, errors: Error = 'raise',
                  timeout: Optional[float] = None, return_key: ReturnKey = 'none'):
         assert errors in get_args(Error)
         assert return_key in get_args(ReturnKey)
@@ -102,7 +102,7 @@ class Mapping(Generic[T]):
             raise TypeError("input iterable has no length")
         return self._n_inputs
 
-    def __iter__(self) -> Union[Iterable[Union[T, Exception]], Iterable[Tuple[Any, Union[T, Exception]]]]:
+    def __iter__(self) -> Iterator[T]:
         return self._results
 
     def _batch_inputs(self, inputs: Iterable[Args]) -> Iterable[List[Args]]:
@@ -178,7 +178,7 @@ class SingularMapping(Mapping[T]):
         super().__init__(workforce, *args, **kwargs)
         self.workforce = workforce
 
-    def __iter__(self) -> Union[Iterable[Union[T, Exception]], Iterable[Tuple[Any, Union[T, Exception]]]]:
+    def __iter__(self) -> Iterator[T]:
         try:
             yield from super().__iter__()
         finally:

--- a/ultima/_mapping.py
+++ b/ultima/_mapping.py
@@ -3,7 +3,7 @@ from functools import partial
 from collections.abc import Sized
 from concurrent.futures import BrokenExecutor
 from typing import Optional, Callable, Iterable, Iterator, List, \
-    Collection, Generic, TypeVar, TYPE_CHECKING, get_args
+    Collection, Generic, TypeVar, TYPE_CHECKING, get_args, cast
 
 from .bfr import BufferedFutureResolver, KeyedFuture
 from .args import Args
@@ -95,7 +95,7 @@ class Mapping(Generic[T]):
         results = self._handle_workforce_failures(results, workforce)
         if self.return_key == 'none':
             results = (i[1] for i in results)
-        self._results = results
+        self._results = cast(Iterator[T], results)
 
     def __len__(self) -> int:
         if self._n_inputs is None:

--- a/ultima/_registry.py
+++ b/ultima/_registry.py
@@ -1,5 +1,5 @@
 import hashlib
-from typing import Union, Callable, TypeVar, Iterator, Generic, Mapping
+from typing import Union, Callable, TypeVar, Iterator, Generic, Mapping, Dict
 
 from .backend import Backend
 
@@ -17,20 +17,20 @@ class DeserializerMapping(Mapping[KT, VT_co]):
     In addition, values are cached when accessed.
     """
     def __init__(self, items: Mapping[KT, T], deserializer: Callable[[T], VT_co]):
-        self.items = items
-        self.deserializer = deserializer
-        self._cache = {}
+        self._items = items
+        self._deserializer = deserializer
+        self._cache: Dict[KT, VT_co] = {}
 
     def __getitem__(self, key: KT) -> VT_co:
         if key not in self._cache:
-            self._cache[key] = self.deserializer(self.items[key])
+            self._cache[key] = self._deserializer(self._items[key])
         return self._cache[key]
 
     def __len__(self) -> int:
-        return len(self.items)
+        return len(self._items)
 
     def __iter__(self) -> Iterator[KT]:
-        return iter(self.items)
+        return iter(self._items)
 
 
 class SerializedItemsRegistry(Generic[T]):

--- a/ultima/backend.py
+++ b/ultima/backend.py
@@ -11,7 +11,7 @@ import multiprocessing.managers
 import concurrent.futures
 from functools import partial
 from abc import ABC, abstractmethod
-from typing import Union, Type, TypeVar, Literal
+from typing import Union, Type, TypeVar, Literal, Optional, overload
 
 import dill
 
@@ -44,7 +44,7 @@ class Backend(ABC):
 
     @classmethod
     @abstractmethod
-    def parse_n_workers(cls, n_workers: Union[int, float, None]) -> int:
+    def parse_n_workers(cls, n_workers) -> int:
         """
         Parse the `n_workers` parameters in the context of the relevant backend
         and return the actual number of workers to use.
@@ -112,10 +112,16 @@ class Backend(ABC):
 
 
 BackendType = TypeVar('BackendType', bound=Backend)
-BackendArgument = Union[str, BackendType, Type[BackendType]]
+BackendArgument = Union[str, Backend, Type[Backend]]
 
 
-def get_backend(name_or_backend: BackendArgument) -> BackendType:
+@overload
+def get_backend(name_or_backend: Union[BackendType, Type[BackendType]]) -> BackendType: ...
+@overload
+def get_backend(name_or_backend: str) -> Backend: ...
+
+
+def get_backend(name_or_backend: BackendArgument):
     """
     Get a Backend object by name or, if already providing a backend class or object,
     returns an instance of the backend.
@@ -199,7 +205,7 @@ class MultiprocessingBackend(Backend):
         Name of the multiprocessing context used by this backend.
     """
     NAME = "multiprocessing"
-    CONTEXT = None
+    CONTEXT: Optional[str] = None
 
     def __init__(self):
         self._manager = None

--- a/ultima/bfr.py
+++ b/ultima/bfr.py
@@ -1,7 +1,7 @@
 import time
 import threading
 import concurrent.futures
-from typing import Iterable, Iterator, Optional, Generic, TypeVar, Tuple, Any
+from typing import Iterable, Iterator, Dict, Optional, Generic, TypeVar, Tuple, Any
 
 from .utils import class_logger
 
@@ -63,7 +63,7 @@ class BufferedFutureResolver(Generic[T]):
         self.lock = threading.Lock()
         self.evt_new_future = threading.Event()
         self.evt_new_capacity = threading.Event()
-        self.futures = {}
+        self.futures: Dict[concurrent.futures.Future, T] = {}
 
         self.feeder_thread = threading.Thread(
             target=self._feeder_thread_impl,

--- a/ultima/bfr.py
+++ b/ultima/bfr.py
@@ -1,7 +1,7 @@
 import time
 import threading
 import concurrent.futures
-from typing import Iterable, Optional, Generic, TypeVar, Tuple, Any
+from typing import Iterable, Iterator, Optional, Generic, TypeVar, Tuple, Any
 
 from .utils import class_logger
 
@@ -71,7 +71,7 @@ class BufferedFutureResolver(Generic[T]):
             name=None if self.name is None else f"{self.name}-FeederThread"
         )
 
-    def __iter__(self) -> Iterable[Tuple[T, Any]]:
+    def __iter__(self) -> Iterator[Tuple[T, Any]]:
         self._start_time = time.monotonic()
         self.feeder_thread.start()
         yield from self._futures_iter()

--- a/ultima/tests/test_ultima.py
+++ b/ultima/tests/test_ultima.py
@@ -8,7 +8,7 @@ import signal
 import weakref
 import itertools
 import threading
-from numbers import Number
+from typing import Optional
 from functools import partial
 from contextlib import contextmanager
 from concurrent.futures import BrokenExecutor
@@ -18,6 +18,7 @@ import pytest
 
 from ultima import Workforce, Args, ultimap, MultiprocessingBackend, ThreadingBackend, InlineBackend
 from ultima.utils import class_logger
+from ultima.typing import Error
 
 
 #
@@ -428,7 +429,7 @@ class TestInline:
     @pytest.mark.parametrize("batch_size", [1, 2])
     @pytest.mark.parametrize("errors", ['ignore', 'log', 'raise', 'return'])
     @pytest.mark.parametrize("timeout", [None, 10])
-    def test_inline_multi(self, ordered, buffering, batch_size, errors, timeout: Number):
+    def test_inline_multi(self, ordered, buffering, batch_size, errors: Error, timeout: Optional[float]):
         with Workforce('inline', n_workers=0) as workforce:
             result = sum(workforce.map(
                 Func.pow2, range(10), ordered=ordered, buffering=buffering, batch_size=batch_size, errors=errors,

--- a/ultima/typing.py
+++ b/ultima/typing.py
@@ -1,10 +1,11 @@
 """
 This module contains types that are outward-facing, to be imported and used by users of the package.
 """
-from typing import Literal
+from typing import Literal, Union
 
 from .backend import BackendArgument
 
 
 ReturnKey = Literal['none', 'idx', 'input']
-Error = Literal['raise', 'return', 'ignore', 'log']
+_ErrorNotReturn = Literal['raise', 'ignore', 'log']
+Error = Union[_ErrorNotReturn, Literal['return']]

--- a/ultima/typing.py
+++ b/ultima/typing.py
@@ -7,5 +7,4 @@ from .backend import BackendArgument
 
 
 ReturnKey = Literal['none', 'idx', 'input']
-_ErrorNotReturn = Literal['raise', 'ignore', 'log']
-Error = Union[_ErrorNotReturn, Literal['return']]
+Error = Literal['raise', 'ignore', 'log', 'return']

--- a/ultima/workforce.py
+++ b/ultima/workforce.py
@@ -2,11 +2,11 @@ import sys
 import weakref
 import threading
 import concurrent.futures
-from typing import Union, Literal, Callable, Iterable, Optional, TypeVar, get_args
+from typing import Union, Tuple, Literal, Callable, Iterable, Optional, TypeVar, get_args, overload
 
 from .args import Args
-from .typing import Error, ReturnKey
 from .utils import SyncCounter, class_logger
+from .typing import Error, ReturnKey, _ErrorNotReturn
 from .backend import get_backend, InlineBackend, BackendArgument
 from ._workerapi import WorkerAPI
 from ._registry import SerializedItemsRegistry
@@ -15,6 +15,7 @@ from ._recursive import make_recursive
 
 
 T = TypeVar("T")
+S = TypeVar("S")
 ShutdownMode = Literal['auto', 'wait', 'nowait']
 
 
@@ -86,9 +87,39 @@ class Workforce:
         )
         self.active = True
 
-    def map(self, func: Callable[..., T], inputs: Iterable, *, ordered: bool = False, buffering: Optional[int] = None,
+    @overload
+    def map(self, func: Callable[..., T], inputs: Iterable, *, ordered: bool = ..., buffering: Optional[int] = ...,
+            batch_size: int = ..., errors: _ErrorNotReturn = ..., timeout: Optional[float] = ...,
+            return_key: Literal['none'] = ..., recursive: bool = ...) -> Mapping[T]: ...
+
+    @overload
+    def map(self, func: Callable[..., T], inputs: Iterable, *, ordered: bool = ..., buffering: Optional[int] = ...,
+            batch_size: int = ..., errors: _ErrorNotReturn = ..., timeout: Optional[float] = ...,
+            return_key: Literal['idx'], recursive: bool = ...) -> Mapping[Tuple[int, T]]: ...
+
+    @overload
+    def map(self, func: Callable[..., T], inputs: Iterable[S], *, ordered: bool = ..., buffering: Optional[int] = ...,
+            batch_size: int = ..., errors: _ErrorNotReturn = ..., timeout: Optional[float] = ...,
+            return_key: Literal['input'], recursive: bool = ...) -> Mapping[Tuple[S, T]]: ...
+
+    @overload
+    def map(self, func: Callable[..., T], inputs: Iterable, *, ordered: bool = ..., buffering: Optional[int] = ...,
+            batch_size: int = ..., errors: Literal['return'], timeout: Optional[float] = ...,
+            return_key: Literal['none'] = ..., recursive: bool = ...) -> Mapping[Union[T, Exception]]: ...
+
+    @overload
+    def map(self, func: Callable[..., T], inputs: Iterable, *, ordered: bool = ..., buffering: Optional[int] = ...,
+            batch_size: int = ..., errors: Literal['return'], timeout: Optional[float] = ...,
+            return_key: Literal['idx'], recursive: bool = ...) -> Mapping[Tuple[int, Union[T, Exception]]]: ...
+
+    @overload
+    def map(self, func: Callable[..., T], inputs: Iterable[S], *, ordered: bool = ..., buffering: Optional[int] = ...,
+            batch_size: int = ..., errors: Literal['return'], timeout: Optional[float] = ...,
+            return_key: Literal['input'], recursive: bool = ...) -> Mapping[Tuple[S, Union[T, Exception]]]: ...
+
+    def map(self, func: Callable, inputs: Iterable, *, ordered: bool = False, buffering: Optional[int] = None,
             batch_size: int = 1, errors: Error = 'raise', timeout: Optional[float] = None,
-            return_key: ReturnKey = 'none', recursive: bool = False) -> Mapping[T]:
+            return_key: ReturnKey = 'none', recursive: bool = False) -> Mapping:
         """
         Map a function over several inputs, performing the tasks by the workers.
 
@@ -285,10 +316,57 @@ class Workforce:
             raise RuntimeError("This workforce instance has already been shut down")
 
 
-def ultimap(func: Callable[..., T], inputs: Iterable, *, ordered: bool = False, buffering: Optional[int] = None,
+@overload
+def ultimap(func: Callable[..., T], inputs: Iterable, *, ordered: bool = ..., buffering: Optional[int] = ...,
+            batch_size: int = ..., errors: _ErrorNotReturn = ..., timeout: Optional[float] = ...,
+            return_key: Literal['none'] = ..., recursive: bool = ..., backend: BackendArgument = ...,
+            n_workers: Union[int, float, None] = ..., shutdown_mode: ShutdownMode = ...) -> SingularMapping[T]: ...
+
+
+@overload
+def ultimap(func: Callable[..., T], inputs: Iterable, *, ordered: bool = ..., buffering: Optional[int] = ...,
+            batch_size: int = ..., errors: _ErrorNotReturn = ..., timeout: Optional[float] = ...,
+            return_key: Literal['idx'], recursive: bool = ..., backend: BackendArgument = ...,
+            n_workers: Union[int, float, None] = ...,
+            shutdown_mode: ShutdownMode = ...) -> SingularMapping[Tuple[int, T]]: ...
+
+
+@overload
+def ultimap(func: Callable[..., T], inputs: Iterable[S], *, ordered: bool = ..., buffering: Optional[int] = ...,
+            batch_size: int = ..., errors: _ErrorNotReturn = ..., timeout: Optional[float] = ...,
+            return_key: Literal['input'], recursive: bool = ..., backend: BackendArgument = ...,
+            n_workers: Union[int, float, None] = ...,
+            shutdown_mode: ShutdownMode = ...) -> SingularMapping[Tuple[S, T]]: ...
+
+
+@overload
+def ultimap(func: Callable[..., T], inputs: Iterable, *, ordered: bool = ..., buffering: Optional[int] = ...,
+            batch_size: int = ..., errors: Literal['return'], timeout: Optional[float] = ...,
+            return_key: Literal['none'] = ..., recursive: bool = ..., backend: BackendArgument = ...,
+            n_workers: Union[int, float, None] = ...,
+            shutdown_mode: ShutdownMode = ...) -> SingularMapping[Union[T, Exception]]: ...
+
+
+@overload
+def ultimap(func: Callable[..., T], inputs: Iterable, *, ordered: bool = ..., buffering: Optional[int] = ...,
+            batch_size: int = ..., errors: Literal['return'], timeout: Optional[float] = ...,
+            return_key: Literal['idx'], recursive: bool = ..., backend: BackendArgument = ...,
+            n_workers: Union[int, float, None] = ...,
+            shutdown_mode: ShutdownMode = ...) -> SingularMapping[Tuple[int, Union[T, Exception]]]: ...
+
+
+@overload
+def ultimap(func: Callable[..., T], inputs: Iterable[S], *, ordered: bool = ..., buffering: Optional[int] = ...,
+            batch_size: int = ..., errors: Literal['return'], timeout: Optional[float] = ...,
+            return_key: Literal['input'], recursive: bool = ..., backend: BackendArgument = ...,
+            n_workers: Union[int, float, None] = ...,
+            shutdown_mode: ShutdownMode = ...) -> SingularMapping[Tuple[S, Union[T, Exception]]]: ...
+
+
+def ultimap(func: Callable, inputs: Iterable, *, ordered: bool = False, buffering: Optional[int] = None,
             batch_size: int = 1, errors: Error = 'raise', timeout: Optional[float] = None,
             return_key: ReturnKey = 'none', recursive: bool = False, backend: BackendArgument = "multiprocessing",
-            n_workers: Union[int, float, None] = None, shutdown_mode: ShutdownMode = 'auto') -> SingularMapping[T]:
+            n_workers: Union[int, float, None] = None, shutdown_mode: ShutdownMode = 'auto') -> SingularMapping:
     """
     A one-liner shortcut for creating a single-use Workforce and using it to map a function over several inputs.
 

--- a/ultima/workforce.py
+++ b/ultima/workforce.py
@@ -6,7 +6,7 @@ from typing import Union, Tuple, Literal, List, Dict, Callable, Iterable, Option
 
 from .args import Args
 from .utils import SyncCounter, class_logger
-from .typing import Error, ReturnKey, _ErrorNotReturn
+from .typing import Error, ReturnKey
 from .backend import get_backend, InlineBackend, BackendArgument
 from ._workerapi import WorkerAPI
 from ._registry import SerializedItemsRegistry
@@ -17,6 +17,7 @@ from ._recursive import make_recursive
 T = TypeVar("T")
 S = TypeVar("S")
 ShutdownMode = Literal['auto', 'wait', 'nowait']
+_ErrorNotReturn = Literal['raise', 'ignore', 'log']
 
 
 class Workforce:


### PR DESCRIPTION
These changes aim to improve the typing of both `Workforce.map` and `ultimap`.
I've added 6(!) `@overload`s per function, to cover all the use cases.

While it would have been far more sensible to have the typing logic a part of `Mapping`, I wasn't able to to solve a major problem: Even if `Mapping` deduces the type of its `__iter__` automatically based on the arguments to its `__init__`, when it is then *wrapped* by the method of `Workforce`, I couldn't get the typing be passed along without repeating all the logic again. You can't specify a type as "whatever overload that was chosen by `Mapping`"...
So for now I gave up, and the typing logic is only present in `Workforce`. The `Mapping` is specifically "told" what its `__iter__` type is from the outside. Since it's an inward-facing class, I believe it's OK. The outward-facing interface is what's important.

In addition, I've also added many smaller typing improvements, so that when the package is checked using `mypy`, it almost passes. There are still minor "errors", but I don't think they're important.